### PR TITLE
Fix these examples to generate the correct sequence.

### DIFF
--- a/Instrumented/python/main.py
+++ b/Instrumented/python/main.py
@@ -55,9 +55,9 @@ def calcfib(n):
         except (ValueError, AssertionError) as e:
             raise ValueError("n must be between 1 and 90") from e
 
-        b, a = 0, 1  # b, a initialized as F(0), F(1)
-        for _ in range(1, n):
-            b, a = a, a + b  # b, a always store F(i-1), F(i)
+        a, b = 0, 1  # a, b initialized as F(0), F(1)
+        for _ in range(1, x):
+        a, b = b, a+b  # a, b always store F(i-1), F(i)
 
         span.set_attribute("fibonacci.result", a)
         return a

--- a/Uninstrumented/python/main.py
+++ b/Uninstrumented/python/main.py
@@ -20,9 +20,9 @@ def calcfib(x):
     except (ValueError, AssertionError) as e:
         raise ValueError("n must be between 1 and 90") from e
 
-    b, a = 0, 1  # b, a initialized as F(0), F(1)
+    a, b = 0, 1  # a, b initialized as F(0), F(1)
     for _ in range(1, x):
-        b, a = a, a + b  # b, a always store F(i-1), F(i)
+        a, b = b, a+b  # a, b always store F(i-1), F(i)
     return a
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fibonacci is 0, 1, 1, 2, 3, 5, 8, 13, ...
The original version generates the sequence starting at 1 instead of at 0. This small change makes it correctly start at 0.